### PR TITLE
Allow calling the script directly

### DIFF
--- a/rekey.sh
+++ b/rekey.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 if [ -z "$FILE_ROOT_DIR" ]; then
   if [ -z "$FILE_ROOT_ENV" ]; then
     FILE_ROOT_ENV=base


### PR DESCRIPTION
Without specifying the interpreter I can't run the script:
```
root@mymaster /root/salt-rekey (master|✔)                                                                                                                                                                            
# ./rekey.sh 
Failed to execute process './rekey.sh'. Reason:
exec: Exec format error
The file './rekey.sh' is marked as an executable but could not be run by the operating system.
```